### PR TITLE
Update resume link and remove unused sections

### DIFF
--- a/index.html
+++ b/index.html
@@ -1,6 +1,5 @@
 <!DOCTYPE html>
-
-</script>
+<html>
   <head>
     <!-- Google tag (gtag.js) -->
 <script async src="https://www.googletagmanager.com/gtag/js?id=G-M6B6FB222D"></script>
@@ -8,7 +7,6 @@
   window.dataLayer = window.dataLayer || [];
   function gtag(){dataLayer.push(arguments);}
   gtag('js', new Date());
-
   gtag('config', 'G-M6B6FB222D');
 </script>
   <meta charset="UTF-8" />
@@ -28,8 +26,6 @@
     <nav>
       <a href="#home">Home</a>
       <a href="#about">About</a>
-      <a href="#work">Work</a>
-      <a href="#blog">Blog</a>
       <a href="resume.pdf" target="_blank">Resume</a>
       <a href="#contact">Contact</a>
     </nav>
@@ -46,23 +42,6 @@
       <p>Hi, I’m Seth — a recent graduate from the Isenberg School of Management at UMass Amherst, where I studied Marketing and earned a certificate in Data Analytics. I’ve always been curious about how people make decisions and how data can help tell better stories.</p>
       <p>I’ve worked in fast-moving environments where showing up, solving problems, and getting results mattered. Whether I was leading a team project, talking to customers, or figuring out a better way to get something done, I leaned into the challenge and learned a lot along the way.</p>
       <p>What drives me most is connection — building strong relationships, understanding what people need, and making things better. I bring energy, empathy, and a strong work ethic to everything I do, and I’m excited to keep learning and growing in whatever comes next.</p>
-    </section>
-
-    <section id="work">
-      <h2>Work Experience</h2>
-      <p><em>Coming soon...</em></p>
-    </section>
-
-    <section id="blog">
-      <h2>Blog</h2>
-      <article>
-        <h3>First Post</h3>
-        <p>This is a short introduction to my blog.</p>
-      </article>
-      <article>
-        <h3>Another Post</h3>
-        <p>Stay tuned for more content coming soon.</p>
-      </article>
     </section>
 
     <section id="contact">


### PR DESCRIPTION
## Summary
- remove Work Experience and Blog from the homepage
- link resume directly to the uploaded PDF

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_685c226807e88321aaed76304c92239c