### PR TITLE
Add hero section and increase page spacing

### DIFF
--- a/index.html
+++ b/index.html
@@ -22,6 +22,11 @@
       <a href="photos.html">Photos</a>
     </nav>
   </header>
+ <section class="hero">
+    <img src="https://images.unsplash.com/photo-1522199710521-72d69614c702?auto=format&fit=crop&w=1200&q=80" alt="Hero image" />
+    <p class="tagline">Data-driven storytelling and creative marketing</p>
+  </section>
+
 
   <main>
     <section id="home">

--- a/style.css
+++ b/style.css
@@ -90,15 +90,34 @@ button#theme-toggle:hover {
   color: #fff;
 }
 
+.hero {
+  width: 100%;
+  text-align: center;
+  padding: 4rem 1rem;
+}
+
+.hero img {
+  width: 100%;
+  max-height: 400px;
+  object-fit: cover;
+  border-radius: 8px;
+  margin-bottom: 1rem;
+}
+
+.hero .tagline {
+  font-size: 1.5rem;
+  margin-top: 1rem;
+}
+
 main {
   max-width: 800px;
-  margin: 2.5rem auto;
+  margin: 4rem auto;
 }
 
 section {
-  margin-bottom: 2.5rem;
+  margin-bottom: 4rem;
   background-color: var(--section-bg);
-  padding: 1.5rem;
+  padding: 2rem;
   border-radius: 8px;
   box-shadow: 0 1px 4px rgba(0, 0, 0, 0.05);
 }


### PR DESCRIPTION
## Summary
- feature hero section with image and tagline on landing page
- style hero to be full width and centered
- expand spacing for main and sections for a cleaner layout

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_685def5fc1a48321929beb4ad65771bc