### PR TITLE
Update styling for lighter theme

### DIFF
--- a/style.css
+++ b/style.css
@@ -1,9 +1,9 @@
 :root[data-theme='light'] {
-  --bg-color: #fafafa;
+  --bg-color: #ffffff;
   --text-color: #333333;
-  --accent-color: #fa8231;
-  --button-bg: #ffffff;
-  --border-color: #dddddd;
+  --accent-color: #808080;
+  --button-bg: #f8f8f8;
+  --border-color: #cccccc;
   --header-footer-bg: #ffffff;
   --section-bg: #ffffff;
 }
@@ -11,7 +11,7 @@
 :root[data-theme='dark'] {
   --bg-color: #121212;
   --text-color: #f3f3f3;
-  --accent-color: #fa8231;
+  --accent-color: #808080;
   --button-bg: #1e1e1e;
   --border-color: #333333;
   --header-footer-bg: #1a1a1a;
@@ -183,7 +183,7 @@ footer {
 }
 
 #contact-form button:hover {
-  background-color: #f58f49;
+  background-color: #666666;
 }
 
 #form-status {


### PR DESCRIPTION
## Summary
- switch orange accent colors to grey
- lighten the light mode background and border colors

## Testing
- `git log -1 --stat`

------
https://chatgpt.com/codex/tasks/task_e_685df6e8c6c48321aa3a5d01e8f6e679