### PR TITLE
Add gradient style

### DIFF
--- a/style.css
+++ b/style.css
@@ -1,7 +1,8 @@
 :root[data-theme='light'] {
   --bg-color: #ffffff;
   --text-color: #333333;
-  --accent-color: #808080;
+  --accent-color: #007bff;
+  --bg-gradient: linear-gradient(to bottom right, #f0f0f0, #b0c7ff, #ffffff);
   --button-bg: #f8f8f8;
   --border-color: #cccccc;
   --header-footer-bg: #ffffff;
@@ -11,7 +12,8 @@
 :root[data-theme='dark'] {
   --bg-color: #121212;
   --text-color: #f3f3f3;
-  --accent-color: #808080;
+  --accent-color: #007bff;
+  --bg-gradient: linear-gradient(to bottom right, #2c2c2c, #0a3d62, #000000);
   --button-bg: #1e1e1e;
   --border-color: #333333;
   --header-footer-bg: #1a1a1a;
@@ -30,12 +32,12 @@
 }
 
 body {
-  background-color: var(--bg-color);
+  background: var(--bg-gradient);
   color: var(--text-color);
   font-family: 'Times New Roman', serif;
   margin: 0;
   padding: 0 1rem;
-  transition: background-color 0.3s ease, color 0.3s ease;
+  transition: background 0.3s ease, color 0.3s ease;
   line-height: 1.6;
 }
 
@@ -72,7 +74,7 @@ nav {
 }
 
 nav a {
-  color: #007bff;
+  color: var(--accent-color);
   text-decoration: none;
   font-weight: 500;
   padding: 0.25rem 0.5rem;
@@ -82,7 +84,7 @@ nav a {
 
 nav a:hover {
   text-decoration: none;
-  background-color: #007bff;
+  background-color: var(--accent-color);
   color: #fff;
 }
 
@@ -103,7 +105,7 @@ button#theme-toggle {
 }
 
 button#theme-toggle:hover {
-  background-color: #007bff;
+  background-color: var(--accent-color);
   color: #fff;
 }
 
@@ -197,7 +199,7 @@ footer {
 }
 
 .contact-button:hover {
-  background-color: #007bff;
+  background-color: var(--accent-color);
   color: #fff;
 }
 


### PR DESCRIPTION
## Summary
- add gradient background variables for light and dark themes
- change accent color to blue and apply across navigation and buttons

## Testing
- `npm test` *(fails: could not find package.json)*
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_685f23f9535483219bf0f9d47c9266fb